### PR TITLE
URL encode cookie values, because phantomjs itself is buggy

### DIFF
--- a/src/Browser/BrowserCookieTrait.php
+++ b/src/Browser/BrowserCookieTrait.php
@@ -11,7 +11,8 @@ use Zumba\GastonJS\Cookie;
 trait BrowserCookieTrait {
   /**
    * Gets the cookies on the browser
-   * @return array
+   *
+   * @return Cookie[]
    */
   public function cookies() {
     $cookies = $this->command('cookies');
@@ -32,6 +33,7 @@ trait BrowserCookieTrait {
     if (isset($cookie["expires"])) {
       $cookie["expires"] = intval($cookie["expires"]) * 1000;
     }
+    $cookie['value'] = urlencode($cookie['value']);
     return $this->command('set_cookie', $cookie);
   }
 

--- a/tests/unit/BrowserCookiesTest.php
+++ b/tests/unit/BrowserCookiesTest.php
@@ -54,6 +54,16 @@ class BrowserCookiesTest extends BrowserCommandsTestCase {
     $this->assertArrayHasKey("mycookie", $this->browser->cookies());
   }
 
+  public function testSetCookieWithSemicolon() {
+    $cookie = array("name" => "mycookie", "value" => "simpletest217107;1443979275;5611600b7875f9.10349470;mDbNZYl4biS9JAGaPLizxz2tcMxIUA429gqcYaYxijM", "path" => "/", "domain" => "127.0.0.1");
+    $this->visitUrl($this->getTestPageBaseUrl() . "/static/basic.html");
+    $this->assertEmpty($this->browser->cookies());
+    $this->assertTrue($this->browser->setCookie($cookie));
+    $this->browser->reload();
+    $this->assertArrayHasKey("mycookie", $this->browser->cookies());
+    $this->assertEquals('simpletest217107;1443979275;5611600b7875f9.10349470;mDbNZYl4biS9JAGaPLizxz2tcMxIUA429gqcYaYxijM', $this->browser->cookies()['mycookie']->getValue());
+  }
+
   public function testCookiesDisabled() {
     $this->assertTrue($this->browser->cookiesEnabled(false));
     $this->visitUrl($this->getTestPageBaseUrl() . "/testCookiesAreNotEmpty/");


### PR DESCRIPTION
If your cookie values contains for example a semicolon, the index.php process will recieve everything before the first semicolon,
given how cookies are stored.
The solution is easy but ideally phantomjs would deal with that.

https://github.com/ariya/phantomjs/issues/12186 report similar issue.